### PR TITLE
Add endPivotTime prop

### DIFF
--- a/src/components/TimeTable/TimeTableView.js
+++ b/src/components/TimeTable/TimeTableView.js
@@ -11,15 +11,13 @@ import Events from '../Events/Events';
 import Header from '../Header/Header';
 import styles from './TimeTableView.styles';
 
-export const TIME_LABELS_COUNT = 22;
-
 export default class TimeTableView extends Component {
   constructor(props) {
     super(props);
     this.state = {
       currentMoment: props.pivotDate,
     };
-    const { pivotTime } = this.props;
+    const { pivotTime,endPivotTime } = this.props;
     this.calendar = null;
     setLocale(props.locale);
     this.times = this.generateTimes(pivotTime);
@@ -43,7 +41,7 @@ export default class TimeTableView extends Component {
 
   generateTimes = (pivotTime) => {
     const times = [];
-    for (let i = pivotTime; i < TIME_LABELS_COUNT; i += 1) {
+    for (let i = pivotTime; i < endPivotTime; i += 1) {
       times.push(i);
     }
     return times;
@@ -117,5 +115,6 @@ TimeTableView.defaultProps = {
   events: [],
   locale: 'en',
   pivotTime: 8,
+  endPivotTime:22
   formatDateHeader: "dddd",
 };


### PR DESCRIPTION
I needed to be able to restrict the start and end times of the time table on my project. 

I added an endPivotTime prop, to limit the times displayed in the time table view.

I effectively removed the const end of day time to replace with a endPivotTime prop with default value 22

Submitting this as a pull request as it might help others. 
